### PR TITLE
[INFRATEAM-3315] adding support for linux/arm64

### DIFF
--- a/expand/BUILD.bazel
+++ b/expand/BUILD.bazel
@@ -17,8 +17,11 @@ go_library(
         "@io_bazel_rules_go//go/platform:ios": [
             "//vendor:libpostal_darwin",
         ],
-        "@io_bazel_rules_go//go/platform:linux": [
-            "//vendor:libpostal_linux",
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "//vendor:libpostal_linux_amd64",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_arm64": [
+            "//vendor:libpostal_linux_arm64",
         ],
         "//conditions:default": [],
     }),

--- a/parser/BUILD.bazel
+++ b/parser/BUILD.bazel
@@ -20,8 +20,11 @@ go_library(
         "@io_bazel_rules_go//go/platform:ios": [
             "//vendor:libpostal_darwin",
         ],
-        "@io_bazel_rules_go//go/platform:linux": [
-            "//vendor:libpostal_linux",
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "//vendor:libpostal_linux_amd64",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_arm64": [
+            "//vendor:libpostal_linux_arm64",
         ],
         "//conditions:default": [],
     }),

--- a/vendor/BUILD.bazel
+++ b/vendor/BUILD.bazel
@@ -13,8 +13,15 @@ cc_import(
 )
 
 cc_import(
-    name = "libpostal_linux",
+    name = "libpostal_linux_amd64",
     hdrs = ["libpostal.h"],
-    static_library = "libpostal_linux.a",
+    static_library = "libpostal_linux_amd64.a",
+    visibility = ["//visibility:public"],
+)
+
+cc_import(
+    name = "libpostal_linux_arm64",
+    hdrs = ["libpostal.h"],
+    static_library = "libpostal_linux_arm64.a",
     visibility = ["//visibility:public"],
 )

--- a/vendor/Dockerfile
+++ b/vendor/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm
 
 RUN apt-get update && apt-get install -y \
   autoconf \

--- a/vendor/Dockerfile
+++ b/vendor/Dockerfile
@@ -22,6 +22,7 @@ WORKDIR $LIBPOSTAL_DIR
 RUN ls
 RUN ./bootstrap.sh
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+      # For ARM64, disable SSE2 optimizations since it uses native NEON instructions instead of SSE.
       ./configure --datadir=$LIBPOSTAL_DATA_DIR --disable-dependency-tracking --disable-sse2; \
     else \
       ./configure --datadir=$LIBPOSTAL_DATA_DIR --disable-dependency-tracking; \

--- a/vendor/Dockerfile
+++ b/vendor/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
   make \
   curl
 
+ARG TARGETPLATFORM
 ARG LIBPOSTAL_VERSION=v1.0.0
 
 ENV LIBPOSTAL_DIR=/opt/libpostal
@@ -20,6 +21,10 @@ RUN tar -xvzf $LIBPOSTAL_VERSION.tar.gz -C $LIBPOSTAL_DIR --strip 1
 WORKDIR $LIBPOSTAL_DIR
 RUN ls
 RUN ./bootstrap.sh
-RUN ./configure --datadir=$LIBPOSTAL_DATA_DIR --disable-dependency-tracking
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+      ./configure --datadir=$LIBPOSTAL_DATA_DIR --disable-dependency-tracking --disable-sse2; \
+    else \
+      ./configure --datadir=$LIBPOSTAL_DATA_DIR --disable-dependency-tracking; \
+    fi
 RUN make
 RUN make install

--- a/vendor/build_linux.sh
+++ b/vendor/build_linux.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
-docker build -t libpostal:latest .
-container_id=$(docker create libpostal:latest)
+if [ "$(uname -m)" = "arm64" ]; then ARCH="arm64"; else ARCH="amd64"; fi
+echo "Building libpostal for linux/$ARCH platform"
+
+docker build --platform linux/$ARCH --load -t libpostal:$ARCH .
+container_id=$(docker create libpostal:$ARCH)
 docker cp "$container_id":/usr/local/include/libpostal/libpostal.h libpostal.h
-docker cp "$container_id":/usr/local/lib/libpostal.a libpostal_linux_amd64.a
+docker cp "$container_id":/usr/local/lib/libpostal.a libpostal_linux_$ARCH.a
 docker rm "$container_id"

--- a/vendor/build_linux.sh
+++ b/vendor/build_linux.sh
@@ -3,5 +3,5 @@
 docker build -t libpostal:latest .
 container_id=$(docker create libpostal:latest)
 docker cp "$container_id":/usr/local/include/libpostal/libpostal.h libpostal.h
-docker cp "$container_id":/usr/local/lib/libpostal.a libpostal_linux.a
+docker cp "$container_id":/usr/local/lib/libpostal.a libpostal_linux_amd64.a
 docker rm "$container_id"

--- a/vendor/build_linux.sh
+++ b/vendor/build_linux.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# To build the static libpostal library for Linux, we use a Docker container.
+# You can use a MacBook with Apple Silicon to build the library for linux/arm64,
+# and RDI Ubuntu instances to build the library for linux/amd64.
 if [ "$(uname -m)" = "arm64" ]; then ARCH="arm64"; else ARCH="amd64"; fi
 echo "Building libpostal for linux/$ARCH platform"
 

--- a/vendor/build_linux_arm64.sh
+++ b/vendor/build_linux_arm64.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-docker build --platform linux/arm64 --load -t libpostal:arm64 .
-container_id=$(docker create --platform linux/arm64 libpostal:arm64)
-docker cp "$container_id":/usr/local/lib/libpostal.a libpostal_linux_arm64.a
-docker rm "$container_id"

--- a/vendor/build_linux_arm64.sh
+++ b/vendor/build_linux_arm64.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+docker build --platform linux/arm64 --load -t libpostal:arm64 .
+container_id=$(docker create --platform linux/arm64 libpostal:arm64)
+docker cp "$container_id":/usr/local/lib/libpostal.a libpostal_linux_arm64.a
+docker rm "$container_id"


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

Adding support for `linux/arm64` so that Opendoor Go services can run in AWS Graviton.

This PR contains the static libraries that were compiled using:
- `libpostal_linux_arm64.a`: MacBook M1 (arm64)
- `libpostal_linux_amd64.a`: RDI Ubuntu instance (amd64)

## Test Plan

Tested in all platforms the build of go services in https://github.com/opendoor-labs/code

```bash
# Update go services dependency to use the top commit of this PR
go get github.com/opendoor-labs/gopostal@68ec48f
go mod tidy
bazel mod tidy

# Build and test the services that use this library
bazel build //go/services/address-parser/...
bazel build //go/services/admiral/...
```

## Mitigation

<!-- Please estimate the potential impact of your change and how we can roll back or mitigate any issues that may arise. Are there feature flags or monitoring in place? -->

## Checklist

<!-- This is a checklist. To mark an item as complete, use [x]. See https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists -->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to external documentation if necessary (READMEs, Confluence, etc.)
- [ ] I have checked that other PRs this PR depends on have already been deployed.
- [ ] I can confirm that if this PR introduces a DB schema change, I have read and followed all the steps outlined in the [Data Contract](https://docs.google.com/document/d/1g_ZZ8TU58Dh2Fn_6aNHktBUNdnBtYNuOyu3GY-kGHnk/edit#heading=h.o2ce6n1q3gpb).

<!-- This PR template is inherited from https://github.com/opendoor-labs/.github -->
