### PR TITLE
Add alias targets for platform-agnostic libpostal references

### DIFF
--- a/vendor/BUILD.bazel
+++ b/vendor/BUILD.bazel
@@ -25,3 +25,22 @@ cc_import(
     static_library = "libpostal_linux_arm64.a",
     visibility = ["//visibility:public"],
 )
+
+# Aliases for platform-agnostic references
+alias(
+    name = "libpostal_linux",
+    actual = select({
+        "@platforms//cpu:x86_64": ":libpostal_linux_amd64",
+        "@platforms//cpu:aarch64": ":libpostal_linux_arm64",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libpostal_darwin_generic",
+    actual = select({
+        "@platforms//cpu:x86_64": ":libpostal_darwin",
+        "@platforms//cpu:aarch64": ":libpostal_darwin_aarch64",
+    }),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
## Problem

The `bazelgenlink` command is failing with the error:
```
no such target '@@gazelle~~go_deps~com_github_opendoor_labs_gopostal//vendor:libpostal_linux': target 'libpostal_linux' not declared in package 'vendor'
```

This occurs because some dependency is referencing `libpostal_linux` (without architecture suffix), but the BUILD file only defines architecture-specific targets like `libpostal_linux_amd64` and `libpostal_linux_arm64`.

## Solution

Added `alias` rules that provide platform-agnostic target names:

- `libpostal_linux` - maps to the correct Linux architecture variant based on target CPU
- `libpostal_darwin_generic` - maps to the correct Darwin architecture variant based on target CPU

These aliases use Bazel's `select()` to choose the appropriate architecture-specific target at build time.

## Testing

This should fix the `bazelgenlink` error by providing the missing `libpostal_linux` target that dependency resolution is looking for.