### PR TITLE
fix: fixing no such target libpostal_linux error

### DIFF
--- a/expand/BUILD.bazel
+++ b/expand/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
     ],
     cdeps = select({
         "@io_bazel_rules_go//go/platform:android": [
-            "//vendor:libpostal_linux",
+            "//vendor:libpostal_linux_amd64",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
             "//vendor:libpostal_darwin",

--- a/parser/BUILD.bazel
+++ b/parser/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
     ],
     cdeps = select({
         "@io_bazel_rules_go//go/platform:android": [
-            "//vendor:libpostal_linux",
+            "//vendor:libpostal_linux_amd64",
         ],
         "@io_bazel_rules_go//go/platform:darwin_amd64": [
             "//vendor:libpostal_darwin",


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

fixing no such target libpostal_linux error

## Test Plan

Test in the code repository:
```
# setup to use this fix
go get github.com/opendoor-labs/gopostal@6bd6ec57c214a238a6b08a2748f1132c1b695210
go mod tidy

# test case 1
bazel query "deps(//go/services/admiral:image.tar)"

# test case 2
bazelgenlink //protobuf/... //go/lib/... //go/services/... //go/tools/...
```

## Mitigation

<!-- Please estimate the potential impact of your change and how we can roll back or mitigate any issues that may arise. Are there feature flags or monitoring in place? -->

## Checklist

<!-- This is a checklist. To mark an item as complete, use [x]. See https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists -->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to external documentation if necessary (READMEs, Confluence, etc.)
- [ ] I have checked that other PRs this PR depends on have already been deployed.
- [ ] I can confirm that if this PR introduces a DB schema change, I have read and followed all the steps outlined in the [Data Contract](https://docs.google.com/document/d/1g_ZZ8TU58Dh2Fn_6aNHktBUNdnBtYNuOyu3GY-kGHnk/edit#heading=h.o2ce6n1q3gpb).

<!-- This PR template is inherited from https://github.com/opendoor-labs/.github -->
